### PR TITLE
Adjusting multiple environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,7 @@ const app = express();
 const port = 3000;
 
 const ContextMiddleware = (req, res, next) => {
-	const requestResource = new AsyncResource('REQUEST_CONTEXT');
-	requestResource.runInAsyncScope(() => {
-		Context.create({
-			val: true
-		});
-		next();
-	});
+    Context.run(next, { val: true });
 };
 
 app.use('/', ContextMiddleware);

--- a/example/middleware.js
+++ b/example/middleware.js
@@ -1,12 +1,5 @@
-const {  AsyncResource  } = require('async_hooks');
 const Context = require('../src');
 
 module.exports = (req, res, next) => {
-	const asyncResource = new AsyncResource('REQUEST_CONTEXT');
-	return asyncResource.runInAsyncScope(() => {
-		Context.create({
-			val: true
-		});
-		next();
-	});
+	Context.run(next, { val: true });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-execution-context",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Provides execution context wrapper for node JS, can be used to create execution wrapper for handling requests and more",
   "author": "Oded Goldglas <odedglas@gmail.com>",
   "license": "ISC",

--- a/src/hooks/constants.js
+++ b/src/hooks/constants.js
@@ -4,4 +4,10 @@
  * We can skip those types assuming the execution context won't be used for process types.
  * @type {Set<String>}
  */
-exports.EXCLUDED_ASYNC_TYPES  = new Set(['DNSCHANNEL', 'TLSWRAP', 'TCPWRAP', 'HTTPPARSER']);
+exports.EXCLUDED_ASYNC_TYPES  = new Set([
+    'DNSCHANNEL',
+    'TLSWRAP',
+    'TCPWRAP',
+    'HTTPPARSER',
+    'ZLIB'
+]);

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -11,7 +11,7 @@ const getContextRef = (parentContext, triggerAsyncId) => (
 );
 
 /**
- * Suspends a given function execution over process next tick.
+ * Suspends a given f   unction execution over process next tick.
  * @param {Function} fn - The function to trigger upon next tick.
  * @param {...any} args - The function arguments to trigger with.
  * @return {any}

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ const createExecutionContext = () => {
          * @returns void
          */
         create: (initialContext = {}) => {
+            console.log('Creating execution context : ', executionContextMap);
             const asyncId = asyncHooks.executionAsyncId();
 
             // Creation is allowed once per execution context

--- a/src/lib/ExecutionContextResource.js
+++ b/src/lib/ExecutionContextResource.js
@@ -1,0 +1,11 @@
+const { AsyncResource } = require('async_hooks');
+
+const ASYNC_RESOURCE_TYPE = 'REQUEST_CONTEXT';
+
+class ExecutionContextResource extends AsyncResource {
+    constructor() {
+        super(ASYNC_RESOURCE_TYPE);
+    }
+}
+
+module.exports = ExecutionContextResource;

--- a/src/lib/ExecutionContextResource.js
+++ b/src/lib/ExecutionContextResource.js
@@ -2,6 +2,9 @@ const { AsyncResource } = require('async_hooks');
 
 const ASYNC_RESOURCE_TYPE = 'REQUEST_CONTEXT';
 
+/**
+ * Wraps node AsyncResource with predefined type.
+ */
 class ExecutionContextResource extends AsyncResource {
     constructor() {
         super(ASYNC_RESOURCE_TYPE);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -30,3 +30,30 @@ interface HookCallbacks {
      */
     destroy?(asyncId: number): void;
 }
+
+interface ExecutionContextAPI {
+
+    /**
+     * Creates an execution context for the current asyncId process.
+     * @param initialContext
+     */
+    create(initialContext: object): void;
+
+    /**
+     * Updates the current async process context.
+     * @param update
+     */
+    update(update: object): void;
+
+    /**
+     * Gets the current async process execution context.
+     */
+    get(): object
+
+    /**
+     * Runs a given function within an async resource context
+     * @param fn
+     * @param initialContext
+     */
+    run(fn: Function, initialContext: object): void
+}


### PR DESCRIPTION
**Main changes:**
- Handling multiple runtimes, exposing one single API upon node `global`.
- Added `run` API, used to ensure a unique execution context id per run.

**Side effects**
- Migrated `suspendDelete` to just suspending child removal checks.